### PR TITLE
Support visible attribute

### DIFF
--- a/core/src/main/java/de/topobyte/osm4j/pbf/seq/PrimParser.java
+++ b/core/src/main/java/de/topobyte/osm4j/pbf/seq/PrimParser.java
@@ -219,8 +219,14 @@ public class PrimParser
 
 	public OsmMetadata convertMetadata(Osmformat.Info info)
 	{
+		boolean visible = true;
+
+		if (info.hasVisible() && !info.getVisible()) {
+			visible = info.getVisible();
+		}
+
 		Metadata metadata = new Metadata(info.getVersion(), getTimestamp(info),
-				info.getUid(), strings[info.getUserSid()], info.getChangeset());
+				info.getUid(), strings[info.getUserSid()], info.getChangeset(), visible);
 		return metadata;
 	}
 


### PR DESCRIPTION
Present in history dumps.

Depends on topobyte/osm4j-core#2