### PR TITLE
Check for presence of user metadata subset

### DIFF
--- a/core/src/main/java/de/topobyte/osm4j/pbf/seq/PrimParser.java
+++ b/core/src/main/java/de/topobyte/osm4j/pbf/seq/PrimParser.java
@@ -291,9 +291,15 @@ public class PrimParser
 			if (fetchMetadata && nodes.hasDenseinfo()) {
 				version = denseInfo.getVersion(i);
 				timestamp += denseInfo.getTimestamp(i);
-				uid += denseInfo.getUid(i);
-				userSid += denseInfo.getUserSid(i);
-				changeset += denseInfo.getChangeset(i);
+				if (denseInfo.getUidCount() > 0) {
+					uid += denseInfo.getUid(i);
+				}
+				if (denseInfo.getUserSidCount() > 0) {
+					userSid += denseInfo.getUserSid(i);
+				}
+				if (denseInfo.getChangesetCount() > 0) {
+					changeset += denseInfo.getChangeset(i);
+				}
 				boolean visible = true;
 				if (hasVisible) {
 					visible = denseInfo.getVisible(i);
@@ -357,9 +363,15 @@ public class PrimParser
 			if (fetchMetadata && nodes.hasDenseinfo()) {
 				version = denseInfo.getVersion(i);
 				timestamp += denseInfo.getTimestamp(i);
-				uid += denseInfo.getUid(i);
-				userSid += denseInfo.getUserSid(i);
-				changeset += denseInfo.getChangeset(i);
+				if (denseInfo.getUidCount() > 0) {
+					uid += denseInfo.getUid(i);
+				}
+				if (denseInfo.getUserSidCount() > 0) {
+					userSid += denseInfo.getUserSid(i);
+				}
+				if (denseInfo.getChangesetCount() > 0) {
+					changeset += denseInfo.getChangeset(i);
+				}
 				boolean visible = true;
 				if (hasVisible) {
 					visible = denseInfo.getVisible(i);


### PR DESCRIPTION
Some PBFs may contain partial metadata without empty values for `uid`, `user`, and `changeset`. This prevents an IndexOutOfBoundsException when attempting to read such files.

I don't know how to generate such a PBF for a test fixture (and Peru is too large), so swapping in http://download.geofabrik.de/south-america/peru-180101.osm.pbf for `data-with-metadata.pbf` will trigger the bug in `TestReadWithMetadata`.